### PR TITLE
MovieWriter fps changes to fix issue #15

### DIFF
--- a/source/premiere_CC2018/main.cpp
+++ b/source/premiere_CC2018/main.cpp
@@ -382,7 +382,7 @@ static void renderAndWriteAllVideo(exDoExportRec* exportInfoP, prMALError& error
         renderParams.inRenderParamsVersion = kPrSDKExporterUtilitySuiteVersion;
         renderParams.inFinalPixelFormat = PrPixelFormat_BGRA_4444_8u;
         renderParams.inStartTime = exportInfoP->startTime;
-        renderParams.inEndTime = exportInfoP->endTime + frameRateDenominator;
+        renderParams.inEndTime = exportInfoP->endTime;
         renderParams.inReservedProgressPreRender = 0.0; //!!!
         renderParams.inReservedProgressPostRender = 0.0; //!!!
 


### PR DESCRIPTION
I revert f8187d0, because i was wrong with it.
Current solution for issue #15 was tested on 1m15s files with different fps settings: https://www.dropbox.com/sh/4xki0t9vdsxjp46/AACGFpwL_0KXZoVd4Eoz3fkba?dl=0

Timebase of output files differ from Hap-QT, for example:
Hap-CC 25fps: codec_time_base = 1/25, time_base=1/12800
Hap-QT 25fps: codec_time_base = 1/25, timebase=1/25

But muxer seems to calculate parameters right way:
d3 and AE now read Hap-CC files without frame loss, show right fps and right duration.