### PR TITLE
UI Chunking auto settings

### DIFF
--- a/source/premiere_CC2018/configure.hpp
+++ b/source/premiere_CC2018/configure.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #define HAPSpecificCodecGroup           "HAPSpecificCodecGroup"
+#define HAPChunk                        "HAPChunk"
 #define HAPChunkCount                   "HAPChunkCount"
 
 #define HAP_VIDEOFILETYPE				'hap'
@@ -40,6 +41,11 @@
 #define STR_HAP_QUALITY_0               L"Fast"
 #define STR_HAP_QUALITY_1               L"Normal"
 #define STR_HAP_QUALITY_2               L"Best"
+
+#define STR_HAP_CHUNKS                   L"Hap chunks"
+#define STR_HAP_CHUNKS_NONE              L"None"
+#define STR_HAP_CHUNKS_AUTO              L"Auto"
+#define STR_HAP_CHUNKS_MANUAL            L"Manual"
 
 #define TOP_AUDIO_PARAM_GROUP_NAME      L"Audio parameters"
 #define BASIC_AUDIO_PARAM_GROUP_NAME    L"Basic Audio Setings"

--- a/source/premiere_CC2018/main.cpp
+++ b/source/premiere_CC2018/main.cpp
@@ -336,10 +336,7 @@ static void renderAndWriteAllVideo(exDoExportRec* exportInfoP, prMALError& error
     const int64_t frameRateNumerator = ticksPerSecond;
     const int64_t frameRateDenominator = ticksPerFrame.value.timeValue;
 
-    // currently 0 means auto, which until we have more information about the playback device will be 1 chunk
-    unsigned int chunkCountAfterAutoApplied = (chunkCount.optionalParamEnabled == 1) ?
-                                              std::max(1, chunkCount.value.intValue)  // force old param to 1
-                                              : 1;
+    unsigned int chunkCountAfterAutoApplied = std::max(1, chunkCount.value.intValue);
     HapChunkCounts chunkCounts{ chunkCountAfterAutoApplied, chunkCountAfterAutoApplied };
 
 	std::unique_ptr<Codec> codec = std::unique_ptr<Codec>(

--- a/source/premiere_CC2018/premiereParams.cpp
+++ b/source/premiere_CC2018/premiereParams.cpp
@@ -59,7 +59,7 @@ prMALError generateDefaultParams(exportStdParms *stdParms, exGenerateDefaultPara
         widthParam.paramType = exParamType_int;
         widthParam.flags = exParamFlag_none;
         widthValues.rangeMin.intValue = 16;
-        widthValues.rangeMax.intValue = 8192;
+        widthValues.rangeMax.intValue = 16384;
         widthValues.value.intValue = seqWidth.mInt32;
         widthValues.disabled = kPrFalse;
         widthValues.hidden = kPrFalse;
@@ -72,7 +72,7 @@ prMALError generateDefaultParams(exportStdParms *stdParms, exGenerateDefaultPara
         heightParam.paramType = exParamType_int;
         heightParam.flags = exParamFlag_none;
         heightValues.rangeMin.intValue = 16;
-        heightValues.rangeMax.intValue = 8192;
+        heightValues.rangeMax.intValue = 16384;
         heightValues.value.intValue = seqHeight.mInt32;
         heightValues.disabled = kPrFalse;
         heightValues.hidden = kPrFalse;
@@ -397,7 +397,7 @@ prMALError validateParamChanged(exportStdParms *stdParmsP, exParamChangedRec *va
             ADBEVideoQuality,
             &toValidate);
 
-        toValidate.disabled = !enableQuality;
+        toValidate.hidden = !enableQuality;
         settings->exportParamSuite->ChangeParam(exID, 0, ADBEVideoQuality, &toValidate);
     }
 

--- a/source/premiere_CC2018/premiereParams.cpp
+++ b/source/premiere_CC2018/premiereParams.cpp
@@ -265,6 +265,7 @@ prMALError postProcessParams(exportStdParms *stdParmsP, exPostProcessParamsRec *
     bool enableQuality = Codec::getCapabilities(codecSubtype).hasQuality;
     settings->exportParamSuite->GetParamValue(exID, 0, ADBEVideoQuality, &qualityToValidate);
     qualityToValidate.disabled = !enableQuality;
+    qualityToValidate.hidden = !enableQuality;
     settings->exportParamSuite->ChangeParam(exID, 0, ADBEVideoQuality, &qualityToValidate);
 
 
@@ -425,6 +426,7 @@ prMALError validateParamChanged(exportStdParms *stdParmsP, exParamChangedRec *va
             ADBEVideoQuality,
             &toValidate);
 
+        toValidate.disabled = !enableQuality;
         toValidate.hidden = !enableQuality;
         settings->exportParamSuite->ChangeParam(exID, 0, ADBEVideoQuality, &toValidate);
     }

--- a/source/premiere_CC2018/premiereParams.cpp
+++ b/source/premiere_CC2018/premiereParams.cpp
@@ -5,7 +5,8 @@
 
 const int k_chunkingMin = 1;
 const int k_chunkingMax = 64;
-const int k_chunkingBlockSize = 1920*1200;
+const int k_chunkingAutoMax = 16;
+const int k_chunkingAutoBlockSize = 1920*1200;
 enum HapChunkOption {
     kHapChunkNone = 0,
     kHapChunkAuto = 1,
@@ -461,8 +462,8 @@ void chunkSettingsHandler(const csSDK_uint32 exID, ExportSettings *settings)
 	case kHapChunkAuto: // Adjust chunks count to ~ 1920*1200px for each chunk
 		settings->exportParamSuite->GetParamValue(exID, 0, ADBEVideoWidth, &width);
 		settings->exportParamSuite->GetParamValue(exID, 0, ADBEVideoHeight, &height);
-		chunkCountValues.value.intValue = std::min(k_chunkingMax,
-			(int)ceil((float)width.value.intValue * height.value.intValue / k_chunkingBlockSize));
+		chunkCountValues.value.intValue = std::min(k_chunkingAutoMax,
+			(int)ceil((float)width.value.intValue * height.value.intValue / k_chunkingAutoBlockSize));
 		chunkCountValues.disabled = kPrTrue;
 		chunkCountValues.hidden = kPrFalse;
 		break;


### PR DESCRIPTION
Idea behind chunking Auto calc: use chunk for each 2.3MPix block (1920x1200px)
And there are other options: None (classic QT behavior) and Manual

TODO:
- [ ]  decide default setting: No chunking or Auto chunking
- [ ]  screenshots and documentation

Please leave a comments:
Is auto formula OK?
FFMpeg reduce chunk count to land exactly on dxt macroblock border. Shoud i do same?
Default setting: none or auto? (in terms of compatibility with existing software)
Maybe limit max chunks a bit? For example 16 instead of 64...

![chunks](https://user-images.githubusercontent.com/8070617/49698334-75555d00-fbd3-11e8-9fef-1c289482c0d3.png)

https://github.com/Vidvox/hap-qt-codec/issues/31