### PR TITLE
latest foundation and macOS link fixes

### DIFF
--- a/codec/CMakeLists.txt
+++ b/codec/CMakeLists.txt
@@ -16,11 +16,6 @@ target_link_libraries(Codec
     snappy
     squish
     ycocg
-    $<$<PLATFORM_ID:Darwin>:${CoreFoundation}>
-    $<$<PLATFORM_ID:Darwin>:${CoreVideo}>
-    $<$<PLATFORM_ID:Darwin>:${Accelerate}>
-    $<$<PLATFORM_ID:Darwin>:${GLIB2}>
-    $<$<PLATFORM_ID:Darwin>:${ZLIB}>
 )
 
 target_include_directories(Codec

--- a/external/ycocg/CMakeLists.txt
+++ b/external/ycocg/CMakeLists.txt
@@ -19,3 +19,9 @@ target_include_directories(ycocg
     PUBLIC
         .
 )
+
+find_library(Accelerate Accelerate)
+
+target_link_libraries(ycocg
+    $<$<PLATFORM_ID:Darwin>:${Accelerate}>
+)


### PR DESCRIPTION
- latest foundation
- link Accelerate.framework for ycocg target
- remove unused libraries from codec target