### PR TITLE
Fix Windows AME Presets location

### DIFF
--- a/installer/CodecInstaller.cmake
+++ b/installer/CodecInstaller.cmake
@@ -41,7 +41,7 @@ set(CPACK_NSIS_CONTACT "happlugin@disguise.one")
 
 # codec specific component install paths
 set(Foundation_CODEC_SPECIFIC_COMPONENTS Presets)
-set(CPACK_NSIS_Presets_INSTALL_DIRECTORY "$PROFILE\\\\Documents\\\\Adobe\\\\Adobe\ Media\ Encoder\\\\13.0\\\\${Foundation_CODEC_NAME}")
+set(CPACK_NSIS_Presets_INSTALL_DIRECTORY "$PROFILE\\\\Documents\\\\Adobe\\\\Adobe\ Media\ Encoder\\\\13.0")
 
 # macOS presets install script
 if (APPLE)


### PR DESCRIPTION
This places presets in <USER>/Documents/Adobe/Adobe Media Encoder/13.0/Presets where they are correctly detected by AME and Premiere.

They are not placed in a per-encoder subdirectory, despite SDK advice, because they are not detected there.