### PR TITLE
Change the file-format name from "Quicktime HAP Format" to "HAP Movie"

### DIFF
--- a/codec/codec.cpp
+++ b/codec/codec.cpp
@@ -29,7 +29,7 @@ const CodecDetails& CodecRegistry::details()
     
     static CodecDetails details{
         "HAP", // productName
-        "Quicktime HAP Format", // fileFormatName;
+        "HAP Movie", // fileFormatName;
         "HAP", // fileFormatShortName;
         "mov",  // videoFileExt
         FileFormat{'p', 'a', 'h', '\0'}, // fileFormat


### PR DESCRIPTION
"QuickTime" is likely to be confused with Adobe's own QuickTime encoder.